### PR TITLE
allow use of privileged session

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ turf aws \
   --delete
 ```
 
+You can also run using the current AWS credentials (rather than assume a role):
+
+```sh
+turf aws \
+  delete-default-vpcs \
+  --privileged \
+  --delete
+```
+
 ### Deploy Security Hub to AWS Organization
 The AWS Security Hub administrator account manages Security Hub membership for an organization. The organization 
 management account designates the Security Hub administrator account for the organization. The organization management 

--- a/README.yaml
+++ b/README.yaml
@@ -96,6 +96,15 @@ examples: |-
     --delete
   ```
 
+  You can also run using the current AWS credentials (rather than assume a role):
+
+  ```sh
+  turf aws \
+    delete-default-vpcs \
+    --privileged \
+    --delete
+  ```
+
   ### Deploy Security Hub to AWS Organization
   The AWS Security Hub administrator account manages Security Hub membership for an organization. The organization 
   management account designates the Security Hub administrator account for the organization. The organization management 

--- a/aws/guardduty.go
+++ b/aws/guardduty.go
@@ -134,7 +134,7 @@ func EnableGuardDutyAdministratorAccount(region string, administratorAccountRole
 	adminAcctSession := GetSession()
 	adminAccountID := GetAccountID(adminAcctSession, administratorAccountRole)
 
-	enabledRegions := GetEnabledRegions(region, rootRole)
+	enabledRegions := GetEnabledRegions(region, rootRole, false)
 
 	logrus.Info("Enabling organization-wide AWS GuardDuty with the following config:")
 	logrus.Infof("  AWS Management Account %s", rootAccountID)

--- a/aws/securityhub.go
+++ b/aws/securityhub.go
@@ -204,7 +204,7 @@ func EnableSecurityHubAdministratorAccount(region string, administratorAccountRo
 	adminAcctSession := GetSession()
 	adminAccountID := GetAccountID(adminAcctSession, administratorAccountRole)
 
-	enabledRegions := GetEnabledRegions(region, rootRole)
+	enabledRegions := GetEnabledRegions(region, rootRole, false)
 
 	logrus.Info("Enabling organization-wide AWS Security Hub with the following config:")
 	logrus.Infof("  AWS Management Account %s", rootAccountID)
@@ -258,7 +258,7 @@ func validateRegion(enabledRegions []string, region string) bool {
 func DisableSecurityHubGlobalResourceControls(globalCollectionRegion string, role string, isCloudTrailAccount bool) error {
 	session := GetSession()
 	accountID := GetAccountID(session, role)
-	enabledRegions := GetEnabledRegions("us-east-1", role)
+	enabledRegions := GetEnabledRegions("us-east-1", role, false)
 
 	if !validateRegion(enabledRegions, globalCollectionRegion) {
 		return fmt.Errorf("%s is not a valid enabled region in this account", globalCollectionRegion)

--- a/cmd/aws_delete_default_vpcs.go
+++ b/cmd/aws_delete_default_vpcs.go
@@ -23,8 +23,10 @@ import (
 )
 
 var shouldDelete bool
+var isPrivileged bool
 
 const shouldDeleteFlag string = "delete"
+const isPrivilegedFlag string = "privileged"
 
 var deleteDefaultVPCsCmd = &cobra.Command{
 	Use:   "delete-default-vpcs",
@@ -34,12 +36,14 @@ var deleteDefaultVPCsCmd = &cobra.Command{
 	than jumping through hoops, it's easier to delete to default VPCs. This task cannot be accomplished with terraform, 
 	so this command is necessary.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return aws.DeleteDefaultVPCs(region, role, shouldDelete)
+		return aws.DeleteDefaultVPCs(region, role, shouldDelete, isPrivileged)
 	},
 }
 
 func init() {
 	awsCmd.AddCommand(deleteDefaultVPCsCmd)
 
+	deleteDefaultVPCsCmd.Flags().StringVar(&role, roleFlag, "", "The ARN of a role to assume")
+	deleteDefaultVPCsCmd.Flags().BoolVarP(&isPrivileged, isPrivilegedFlag, "", false, "Flag to indicate if the session already has rights to perform the actions in AWS")
 	deleteDefaultVPCsCmd.Flags().BoolVarP(&shouldDelete, shouldDeleteFlag, "", false, "Flag to indicate if the delete should be run")
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudposse/turf
 go 1.15
 
 require (
-	github.com/aws/aws-sdk-go v1.37.23
+	github.com/aws/aws-sdk-go v1.38.3
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/magefile/mage v1.11.0 // indirect
 	github.com/magiconair/properties v1.8.4 // indirect
@@ -16,7 +16,6 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/jwalterweatherman v1.1.0
 	github.com/spf13/viper v1.7.1
-	github.com/stretchr/objx v0.1.1 // indirect
 	golang.org/x/sys v0.0.0-20210304152209-afaa3650a925 // indirect
 	golang.org/x/text v0.3.5 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/jwalterweatherman v1.1.0
 	github.com/spf13/viper v1.7.1
+	github.com/stretchr/objx v0.1.1 // indirect
 	golang.org/x/sys v0.0.0-20210304152209-afaa3650a925 // indirect
 	golang.org/x/text v0.3.5 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/aws/aws-sdk-go v1.37.23 h1:bO80NcSmRv52w+GFpBegoLdlP/Z0OwUqQ9bbeCLCy/0=
-github.com/aws/aws-sdk-go v1.37.23/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.38.3 h1:QCL/le04oAz2jELMRSuJVjGT7H+4hhoQc66eMPCfU/k=
+github.com/aws/aws-sdk-go v1.38.3/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=


### PR DESCRIPTION
## what

Allow use of the current session in the `aws delete-default-vpcs` command via the `--privileged` flag rather than specifying a role ARN

## why

When using an IAM user or AWS SSO, the user can run with the currently exported credentials (or specify a profile) rather than a role ARN. In the following example, the user would be deleting all the VPCs in the `security` account:

```
$ AWS_PROFILE=acme-gbl-security-admin turf aws delete-default-vpcs --privileged --delete
```