### PR TITLE
allow security hub disable controls to run without role

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ turf aws \
   --delete
 ```
 
-You can also run using the current AWS credentials (rather than assume a role):
+You can also run using the current AWS credentials (rather than assuming a role):
 
 ```sh
 turf aws \
@@ -165,6 +165,25 @@ turf aws \
   --global-collector-region us-west-2 \ 
   --cloud-trail-account
 ```
+
+You can also run using the current AWS credentials (rather than assuming a role):
+
+  ```sh
+  turf aws \
+    securityhub \
+    disable-global-controls \
+    --privileged \
+    --global-collector-region us-west-2
+  ```
+
+  ```sh
+  turf aws \
+    securityhub \
+    disable-global-controls \
+    --privileged \
+    --global-collector-region us-west-2 \ 
+    --cloud-trail-account
+  ```
 
 ### Deploy GuardDuty to AWS Organization
 When you use GuardDuty with an AWS Organizations organization, you can designate any account within the organization 

--- a/README.yaml
+++ b/README.yaml
@@ -96,7 +96,7 @@ examples: |-
     --delete
   ```
 
-  You can also run using the current AWS credentials (rather than assume a role):
+  You can also run using the current AWS credentials (rather than assuming a role):
 
   ```sh
   turf aws \
@@ -143,6 +143,25 @@ examples: |-
     --global-collector-region us-west-2 \ 
     --cloud-trail-account
   ```
+
+  You can also run using the current AWS credentials (rather than assuming a role):
+
+    ```sh
+    turf aws \
+      securityhub \
+      disable-global-controls \
+      --privileged \
+      --global-collector-region us-west-2
+    ```
+
+    ```sh
+    turf aws \
+      securityhub \
+      disable-global-controls \
+      --privileged \
+      --global-collector-region us-west-2 \ 
+      --cloud-trail-account
+    ```
 
   ### Deploy GuardDuty to AWS Organization
   When you use GuardDuty with an AWS Organizations organization, you can designate any account within the organization 

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -24,8 +24,9 @@ var region string
 var profile string
 var role string
 
-// These flags are used in the GuardDuty and Security Hub sub-commands
+// These flags are used in the AWS sub-commands
 const roleFlag string = "role"
+const isPrivilegedFlag string = "privileged"
 const adminAccountRoleFlag string = "administrator-account-role"
 const rootRoleFlag string = "root-role"
 

--- a/cmd/aws_delete_default_vpcs.go
+++ b/cmd/aws_delete_default_vpcs.go
@@ -26,7 +26,7 @@ var shouldDelete bool
 var isPrivileged bool
 
 const shouldDeleteFlag string = "delete"
-const isPrivilegedFlag string = "privileged"
+
 
 var deleteDefaultVPCsCmd = &cobra.Command{
 	Use:   "delete-default-vpcs",

--- a/cmd/aws_securityhub_disablecontrol.go
+++ b/cmd/aws_securityhub_disablecontrol.go
@@ -40,16 +40,16 @@ var securityHubDisableGlobalControlsCmd = &cobra.Command{
 	https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-cis-to-disable.html
 	`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return aws.DisableSecurityHubGlobalResourceControls(globalCollectionRegion, role, isCloudTrailAccount)
+		return aws.DisableSecurityHubGlobalResourceControls(globalCollectionRegion, role, isPrivileged, isCloudTrailAccount)
 	},
 }
 
 func init() {
 	securityHubDisableGlobalControlsCmd.Flags().StringVarP(&globalCollectionRegion, globalCollectionRegionFlag, "g", region, "The AWS Region that contains the global resource collector")
 	securityHubDisableGlobalControlsCmd.Flags().StringVar(&role, roleFlag, "", "The ARN of a role to assume")
+	securityHubDisableGlobalControlsCmd.Flags().BoolVarP(&isPrivileged, isPrivilegedFlag, "", false, "Flag to indicate if the session already has rights to perform the actions in AWS")
 	securityHubDisableGlobalControlsCmd.Flags().BoolVar(&isCloudTrailAccount, cloudTrailAccountFlag, false, "A flag to indicate if this account is the central CloudTrail account")
 
-	securityHubDisableGlobalControlsCmd.MarkFlagRequired(roleFlag)
 	securityHubDisableGlobalControlsCmd.MarkFlagRequired(globalCollectionRegionFlag)
 
 	securityhubCmd.AddCommand(securityHubDisableGlobalControlsCmd)


### PR DESCRIPTION
## what

Allow use of the current session in the `aws disable-global-controls` command via the `--privileged` flag rather than specifying a role ARN

## why

When using an IAM user or AWS SSO, the user can run with the currently exported credentials (or specify a profile) rather than a role ARN. In the following example, the user would be deleting all the Security Hub Global Controls in the `security` account:

```
$ AWS_PROFILE=acme-gbl-security-admin turf aws disable-global-controls --global-collector-region us-east-1 --privileged
```