### PR TITLE
revert change excluding ap-northeast-3

### DIFF
--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -64,12 +64,7 @@ func GetEnabledRegions(region string, role string, isPrivileged bool) []string {
 
 	regionsList := make([]string, 0)
 	for i := range regions.Regions {
-		// https://github.com/aws/aws-sdk-go/issues/3805
-		// exclude the `ap-northeast-3` region until the sdk is updated to support its endpoints
-		currentRegion := *regions.Regions[i].RegionName
-		if currentRegion != "ap-northeast-3" {
-			regionsList = append(regionsList, *regions.Regions[i].RegionName)
-		}
+		regionsList = append(regionsList, *regions.Regions[i].RegionName)
 	}
 
 	return regionsList

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudposse/turf
 go 1.15
 
 require (
-	github.com/aws/aws-sdk-go v1.38.3
+	github.com/aws/aws-sdk-go v1.38.18
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/magefile/mage v1.11.0 // indirect
 	github.com/magiconair/properties v1.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/aws/aws-sdk-go v1.38.3 h1:QCL/le04oAz2jELMRSuJVjGT7H+4hhoQc66eMPCfU/k=
-github.com/aws/aws-sdk-go v1.38.3/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.38.18 h1:Y5W5siOHoiZbCHQcoEiih267L21sbw1FW+2Vdlq9dlU=
+github.com/aws/aws-sdk-go v1.38.18/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=


### PR DESCRIPTION
# what

- Revert change excluding `ap-northeast-3` region from the enabled regions API call 

# why

- The AWS SDK for Go now generates endpoints for the `ap-northeast-3` region and an [issue](https://github.com/aws/aws-sdk-go/issues/3805) has been closed. 